### PR TITLE
Remove floating elements and make layout fullscreen

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,11 +17,11 @@ export default function Home() {
   }, [])
 
   return (
-    <main className="h-screen w-screen bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 flex items-center justify-center overflow-hidden">
+    <main className="h-screen w-screen bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 overflow-hidden">
       {/* Main Card */}
-      <div className="relative w-full">
+      <div className="relative w-full h-full">
         {/* Background Card */}
-        <div className="bg-gray-900 rounded-3xl p-12 relative overflow-hidden shadow-2xl">
+        <div className="bg-gray-900 h-full w-full p-8 relative overflow-hidden shadow-2xl">
           {/* Top Left Brand */}
           <div className="absolute top-8 left-8 text-gray-400 text-sm font-light tracking-widest">
             Электроника будущего

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,35 +74,7 @@ export default function Home() {
                 7+
               </div>
 
-              {/* Products */}
-              <div className="relative z-10 space-y-8">
-                {/* Top Product - Smartphone */}
-                <div className="transform rotate-12 hover:rotate-6 transition-all duration-500">
-                  <div className="w-80 h-48 bg-gradient-to-br from-gray-800 to-black rounded-3xl flex items-center justify-center relative shadow-2xl border border-gray-700">
-                    <div className="text-8xl opacity-80">📱</div>
-                    <div className="absolute top-4 left-4 w-3 h-3 bg-blue-500 rounded-full animate-pulse"></div>
-                    <div className="absolute bottom-4 right-4 text-xs text-gray-400 font-mono">iPhone 15 Pro</div>
-                  </div>
-                </div>
 
-                {/* Middle Product - Laptop */}
-                <div className="transform -rotate-6 hover:rotate-0 transition-all duration-500 -mt-4">
-                  <div className="w-72 h-44 bg-gradient-to-br from-gray-700 to-gray-900 rounded-3xl flex items-center justify-center relative shadow-2xl border border-gray-600">
-                    <div className="text-7xl opacity-80">💻</div>
-                    <div className="absolute top-4 left-4 w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
-                    <div className="absolute bottom-4 right-4 text-xs text-gray-400 font-mono">MacBook Pro</div>
-                  </div>
-                </div>
-
-                {/* Bottom Product - Headphones */}
-                <div className="transform rotate-3 hover:rotate-12 transition-all duration-500 ml-8">
-                  <div className="w-64 h-40 bg-gradient-to-br from-gray-800 to-black rounded-3xl flex items-center justify-center relative shadow-2xl border border-gray-700">
-                    <div className="text-6xl opacity-80">🎧</div>
-                    <div className="absolute top-4 left-4 w-3 h-3 bg-purple-500 rounded-full animate-pulse"></div>
-                    <div className="absolute bottom-4 right-4 text-xs text-gray-400 font-mono">AirPods Pro</div>
-                  </div>
-                </div>
-              </div>
 
               {/* Floating Elements */}
               <div className="absolute top-1/4 -left-8 w-16 h-16 bg-blue-500/20 rounded-full blur-xl animate-pulse"></div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
   }, [])
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 flex items-center justify-center p-8">
+    <main className="h-screen w-screen bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 flex items-center justify-center overflow-hidden">
       {/* Main Card */}
       <div className="relative max-w-6xl w-full">
         {/* Background Card */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,7 +106,7 @@ export default function Home() {
 
               {/* Floating Elements */}
               <div className="absolute top-1/4 -left-8 w-16 h-16 bg-blue-500/20 rounded-full blur-xl animate-pulse"></div>
-              <div className="absolute bottom-1/4 -right-8 w-20 h-20 bg-cyan-500/20 rounded-full blur-xl animate-pulse animation-delay-1000"></div>
+
               <div className="absolute top-1/2 left-1/4 w-12 h-12 bg-purple-500/20 rounded-full blur-xl animate-pulse animation-delay-500"></div>
             </div>
           </div>
@@ -121,7 +121,7 @@ export default function Home() {
           </div>
 
           {/* Decorative Elements */}
-          <div className="absolute top-1/4 right-1/4 w-2 h-2 bg-blue-500 rounded-full animate-ping"></div>
+
           <div className="absolute bottom-1/3 left-1/3 w-1 h-1 bg-cyan-400 rounded-full animate-ping animation-delay-700"></div>
           <div className="absolute top-1/2 left-1/6 w-1.5 h-1.5 bg-purple-400 rounded-full animate-ping animation-delay-1500"></div>
         </div>
@@ -136,9 +136,7 @@ export default function Home() {
           <div className="text-2xl">⚡</div>
         </div>
         
-        <div className="absolute -right-8 top-1/3 bg-white/10 backdrop-blur-md rounded-full p-4 text-white">
-          <div className="text-2xl">🚀</div>
-        </div>
+
       </div>
 
       {/* Background Pattern */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ export default function Home() {
   return (
     <main className="h-screen w-screen bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 flex items-center justify-center overflow-hidden">
       {/* Main Card */}
-      <div className="relative max-w-6xl w-full">
+      <div className="relative w-full">
         {/* Background Card */}
         <div className="bg-gray-900 rounded-3xl p-12 relative overflow-hidden shadow-2xl">
           {/* Top Left Brand */}


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses layout improvements to create a fullscreen experience. The user requested:
- Making the block fullscreen with no margins
- Removing floating product blocks (iPhone, MacBook, AirPods)
- Cleaning up decorative elements on the right side

## Code changes
- **Layout**: Changed main container from `min-h-screen` with padding to `h-screen w-screen` with `overflow-hidden` for true fullscreen
- **Card styling**: Removed rounded corners and max-width constraints, changed padding from `p-12` to `p-8`
- **Product removal**: Completely removed the products section containing iPhone 15 Pro, MacBook Pro, and AirPods Pro floating cards
- **Decorative cleanup**: Removed several floating decorative elements including right-side rocket emoji and some animated dots
- **Responsive**: Maintained core layout structure while achieving the requested fullscreen appearance

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f7afb9ade162424a85841e8066ea4325/nova-lab)

👀 [Preview Link](https://f7afb9ade162424a85841e8066ea4325-nova-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f7afb9ade162424a85841e8066ea4325</projectId>-->
<!--<branchName>nova-lab</branchName>-->